### PR TITLE
QLWC: Hide cup times from website and api

### DIFF
--- a/app/controllers/api/scores_api_controller.rb
+++ b/app/controllers/api/scores_api_controller.rb
@@ -25,6 +25,8 @@ class Api::ScoresApiController < Api::ApiController
   param_group :mode
   param :limit, Integer, desc: 'Number of records which will be returned'
   def map
+    return render json: { total_records: 0, records: [] } if map_hidden?(params[:map])
+
     render json: Score.map_scores(params)
   end
 
@@ -40,8 +42,18 @@ class Api::ScoresApiController < Api::ApiController
                      :speed_average, :name, 'scores.updated_at as date')
              .find(id)
 
+    return render json: {} if map_hidden?(s.map)
+
     j = s.as_json
     j['rank'] = s.rank_
     render json: j
+  end
+
+  private
+
+  def map_hidden?(map)
+    qlwc = Qlwc.new
+    qlwc.hidden_maps(Time.now.utc).include?(map.downcase) &&
+      params[:cup_key] != ENV['QLRACE_CUP_KEY']
   end
 end

--- a/app/controllers/api/scores_api_controller.rb
+++ b/app/controllers/api/scores_api_controller.rb
@@ -52,8 +52,8 @@ class Api::ScoresApiController < Api::ApiController
   private
 
   def map_hidden?(map)
-    qlwc = Qlwc.new
-    qlwc.hidden_maps(Time.now.utc).include?(map.downcase) &&
+    qlwc = Qlwc.new(Time.now.utc)
+    qlwc.hidden_maps.include?(map.downcase) &&
       params[:cup_key] != ENV['QLRACE_CUP_KEY']
   end
 end

--- a/app/controllers/api/scores_new_controller.rb
+++ b/app/controllers/api/scores_new_controller.rb
@@ -4,9 +4,9 @@ class Api::ScoresNewController < Api::ApiController
   before_action :authenticate, :check_score
 
   def new
-    qlwc = Qlwc.new
+    qlwc = Qlwc.new(@score[:date])
     return head :not_modified if Qlwc::MAPS.include?(@score[:map]) &&
-                                 !qlwc.round_active?(@score[:map], @score[:date])
+                                 !qlwc.round_active?(@score[:map])
 
     @score[:name] = @score[:player_id].to_s if @score[:name].blank?
     return head :bad_request if @score.values.any?(&:blank?)

--- a/app/controllers/api/scores_new_controller.rb
+++ b/app/controllers/api/scores_new_controller.rb
@@ -4,6 +4,10 @@ class Api::ScoresNewController < Api::ApiController
   before_action :authenticate, :check_score
 
   def new
+    qlwc = Qlwc.new
+    return head :not_modified if Qlwc::MAPS.include?(@score[:map]) &&
+                                 !qlwc.round_active?(@score[:map], @score[:date])
+
     @score[:name] = @score[:player_id].to_s if @score[:name].blank?
     return head :bad_request if @score.values.any?(&:blank?)
     return head :not_modified if map_disabled?

--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -13,6 +13,8 @@ class PlayersController < ApplicationController
       .search(params[:search])
       .order(:name)
     )
+    qlwc = Qlwc.new
+    @hidden_maps = qlwc.hidden_maps(Time.now.utc)
   end
 
   # Should maybe be in WorldRecordController?

--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -13,8 +13,8 @@ class PlayersController < ApplicationController
       .search(params[:search])
       .order(:name)
     )
-    qlwc = Qlwc.new
-    @hidden_maps = qlwc.hidden_maps(Time.now.utc)
+    qlwc = Qlwc.new(Time.now.utc)
+    @hidden_maps = qlwc.hidden_maps
   end
 
   # Should maybe be in WorldRecordController?

--- a/app/controllers/scores_controller.rb
+++ b/app/controllers/scores_controller.rb
@@ -10,8 +10,8 @@ class ScoresController < ApplicationController
   def home
     @total_scores = Score.count
 
-    qlwc = Qlwc.new
-    @recent_wrs = WorldRecord.where.not(map: qlwc.hidden_maps(Time.now.utc))
+    qlwc = Qlwc.new(Time.now.utc)
+    @recent_wrs = WorldRecord.where.not(map: qlwc.hidden_maps)
                              .order(updated_at: :desc).includes(:player)
                              .limit(5)
     @map_scores = WorldRecord.map_scores
@@ -20,9 +20,8 @@ class ScoresController < ApplicationController
   def map
     return unless Score.exists?(map: params[:map].downcase)
 
-    qlwc = Qlwc.new
-    hidden_maps = qlwc.hidden_maps(Time.now.utc)
-    return if hidden_maps.include?(params[:map].downcase)
+    qlwc = Qlwc.new(Time.now.utc)
+    return if qlwc.hidden_maps.include?(params[:map].downcase)
 
     @map = Score.map_scores_paginated params
     @pagy = Pagy.new(count: @map[:total_records], page: params[:page])
@@ -48,8 +47,8 @@ class ScoresController < ApplicationController
     mode = params.fetch(:mode, -1).to_i
     records = mode.between?(0, 3) ? model.where(mode: mode) : model
 
-    qlwc = Qlwc.new
-    @pagy, @recent = pagy(records.where.not(map: qlwc.hidden_maps(Time.now.utc))
+    qlwc = Qlwc.new(Time.now.utc)
+    @pagy, @recent = pagy(records.where.not(map: qlwc.hidden_maps)
                                  .order(updated_at: :desc)
                                  .includes(:player))
   end

--- a/app/lib/qlwc.rb
+++ b/app/lib/qlwc.rb
@@ -37,41 +37,45 @@ class Qlwc
                Time.utc(2021, 5, 8, 18), Time.utc(2021, 5, 15, 18),
                Time.utc(2021, 5, 22, 18)].freeze
 
-  def current_map(time)
-    return nil if time < START_DATES[0] || time >= END_DATES[4]
+  def initialize(date)
+    @date = date
+  end
+
+  def current_map()
+    return nil if @date < START_DATES[0] || @date >= END_DATES[4]
 
     MAPS.each_with_index do |map, round|
-      return map if time >= START_DATES[round] && time < END_DATES[round]
+      return map if @date >= START_DATES[round] && @date < END_DATES[round]
     end
 
     nil
   end
 
-  def round_active?(map, time)
+  def round_active?(map)
     round = MAPS.find_index(map)
     return false if round.nil?
 
-    time >= START_DATES[round] && time < END_DATES[round]
+    @date >= START_DATES[round] && @date < END_DATES[round]
   end
 
-  def round_started?(map, time)
+  def round_started?(map)
     round = MAPS.find_index(map)
     return false if round.nil?
 
-    time >= START_DATES[round]
+    @date >= START_DATES[round]
   end
 
-  def round_finished?(map, time)
+  def round_finished?(map)
     round = MAPS.find_index(map)
     return false if round.nil?
 
-    time >= END_DATES[round]
+    @date >= END_DATES[round]
   end
 
-  def hidden_maps(time)
+  def hidden_maps()
     hidden = []
     MAPS.each do |map|
-      hidden << map unless round_finished?(map, time)
+      hidden << map unless round_finished?(map)
     end
     hidden
   end

--- a/app/lib/qlwc.rb
+++ b/app/lib/qlwc.rb
@@ -41,7 +41,7 @@ class Qlwc
     @date = date
   end
 
-  def current_map()
+  def current_map
     return nil if @date < START_DATES[0] || @date >= END_DATES[4]
 
     MAPS.each_with_index do |map, round|
@@ -72,7 +72,7 @@ class Qlwc
     @date >= END_DATES[round]
   end
 
-  def hidden_maps()
+  def hidden_maps
     hidden = []
     MAPS.each do |map|
       hidden << map unless round_finished?(map)

--- a/app/models/score.rb
+++ b/app/models/score.rb
@@ -66,8 +66,8 @@ class Score < ApplicationRecord
       return { name: nil, id: nil, medals: [], records: [] }
     end
 
-    qlwc = Qlwc.new
-    hidden_maps = qlwc.hidden_maps(Time.now.utc)
+    qlwc = Qlwc.new(Time.now.utc)
+    hidden_maps = qlwc.hidden_maps
 
     query = 'SELECT * FROM player_scores(:p_id, :mode)'
     scores = (Score.find_by_sql [query, { p_id: p.id, mode: mode }])

--- a/app/models/score.rb
+++ b/app/models/score.rb
@@ -66,8 +66,12 @@ class Score < ApplicationRecord
       return { name: nil, id: nil, medals: [], records: [] }
     end
 
+    qlwc = Qlwc.new
+    hidden_maps = qlwc.hidden_maps(Time.now.utc)
+
     query = 'SELECT * FROM player_scores(:p_id, :mode)'
-    scores = Score.find_by_sql [query, { p_id: p.id, mode: mode }]
+    scores = (Score.find_by_sql [query, { p_id: p.id, mode: mode }])
+             .select { |s| hidden_maps.exclude?(s[:map]) }
 
     total = 0
     medals = [0, 0, 0]

--- a/app/models/world_record.rb
+++ b/app/models/world_record.rb
@@ -39,8 +39,8 @@ class WorldRecord < ApplicationRecord
   end
 
   def self.map_scores
-    qlwc = Qlwc.new
-    hidden_maps = qlwc.hidden_maps(Time.now.utc)
+    qlwc = Qlwc.new(Time.now.utc)
+    hidden_maps = qlwc.hidden_maps
 
     query = <<-SQL.squish
     SELECT wr.map, wr.mode, wr.time, p.id AS player_id, p.name AS player_name
@@ -64,8 +64,8 @@ class WorldRecord < ApplicationRecord
 
   def self.most_world_records(mode)
     where_mode = mode.to_i == -1 ? '' : " AND mode = #{mode.to_i}"
-    qlwc = Qlwc.new
-    hidden_maps = qlwc.hidden_maps(Time.now.utc)
+    qlwc = Qlwc.new(Time.now.utc)
+    hidden_maps = qlwc.hidden_maps
 
     query = <<-SQL.squish
     SELECT wr.player_id, p.name, COUNT(wr.player_id) AS num_wrs,

--- a/app/models/world_record.rb
+++ b/app/models/world_record.rb
@@ -39,14 +39,18 @@ class WorldRecord < ApplicationRecord
   end
 
   def self.map_scores
+    qlwc = Qlwc.new
+    hidden_maps = qlwc.hidden_maps(Time.now.utc)
+
     query = <<-SQL.squish
     SELECT wr.map, wr.mode, wr.time, p.id AS player_id, p.name AS player_name
     FROM world_records wr
     INNER JOIN players p
     ON wr.player_id = p.id
+    WHERE wr.map NOT IN (?)
     ORDER BY wr.map, wr.mode;
     SQL
-    wrs = WorldRecord.find_by_sql [query]
+    wrs = WorldRecord.find_by_sql [query, hidden_maps]
     map_scores = Hash.new { |hash, key| hash[key] = Array.new(4) }
     wrs.each do |wr|
       map_scores[wr.map][wr.mode] = wr
@@ -60,17 +64,20 @@ class WorldRecord < ApplicationRecord
 
   def self.most_world_records(mode)
     where_mode = mode.to_i == -1 ? '' : " AND mode = #{mode.to_i}"
+    qlwc = Qlwc.new
+    hidden_maps = qlwc.hidden_maps(Time.now.utc)
+
     query = <<-SQL.squish
     SELECT wr.player_id, p.name, COUNT(wr.player_id) AS num_wrs,
         (SELECT COUNT(*)
          FROM scores
          WHERE scores.player_id = wr.player_id#{where_mode}) AS num_records
     FROM world_records wr, players p
-    WHERE wr.player_id = p.id#{where_mode}
+    WHERE wr.player_id = p.id#{where_mode} AND wr.map NOT IN (?)
     GROUP BY p.name, wr.player_id
     ORDER BY num_wrs DESC
     SQL
-    Score.find_by_sql [query]
+    Score.find_by_sql [query, hidden_maps]
   end
 
   def self.update_world_record(world_record, score)

--- a/app/views/players/index.html.slim
+++ b/app/views/players/index.html.slim
@@ -16,7 +16,7 @@
             a href='/player/#{player.id}' #{player.name}
           td.col-xs-4 = player.id
           td.col-xs-2 = player.scores.size
-          td.col-xs-2 = player.world_records.size
+          td.col-xs-2 = player.world_records.where.not(map: @hidden_maps).size
   == pagy_bootstrap_nav(@pagy)
 - else
   p No players were found

--- a/spec/lib/qlwc_spec.rb
+++ b/spec/lib/qlwc_spec.rb
@@ -10,11 +10,10 @@ DATES = [Time.utc(2021, 4, 17), Time.utc(2021, 4, 17, 19),
          Time.utc(2021, 5, 22, 18)].freeze
 
 RSpec.describe Qlwc do
-  let(:qlwc) { described_class.new }
-
   describe 'current_map' do
     it 'returns nil if time is before qlwc21 started' do
-      expect(qlwc.current_map(Time.utc(2021, 4, 13))).to be_nil
+      qlwc = Qlwc.new(Time.utc(2021, 4, 13))
+      expect(qlwc.current_map).to be_nil
     end
 
     it 'returns the current map' do
@@ -23,57 +22,68 @@ RSpec.describe Qlwc do
                  'qlwc21_round2', 'qlwc21_round3', 'qlwc21_round4', nil]
       DATES.zip(results).each do |date, result|
         # puts "#{date} #{result}"
-        expect(qlwc.current_map(date)).to eq(result)
+        qlwc = Qlwc.new(date)
+        expect(qlwc.current_map).to eq(result)
       end
     end
   end
 
   describe 'round_active?' do
     it 'returns false if map is not a qlwc map' do
-      expect(qlwc.round_active?('trinity', DATES[0])).to eq(false)
+      qlwc = Qlwc.new(DATES[0])
+      expect(qlwc.round_active?('trinity')).to eq(false)
     end
 
     it 'returns false if round 0 has not started' do
-      expect(qlwc.round_active?('qlwc21_round0', DATES[0])).to eq(false)
+      qlwc = Qlwc.new(DATES[0])
+      expect(qlwc.round_active?('qlwc21_round0')).to eq(false)
     end
 
     it 'returns true if round 1 is active' do
-      expect(qlwc.round_active?('qlwc21_round1', DATES[5])) == true
+      qlwc = Qlwc.new(DATES[5])
+      expect(qlwc.round_active?('qlwc21_round1')) == true
     end
   end
 
   describe 'round_started?' do
     it 'returns false if round 0 has not started' do
-      expect(qlwc.round_started?('qlwc21_round0', DATES[0])).to eq(false)
+      qlwc = Qlwc.new(DATES[0])
+      expect(qlwc.round_started?('qlwc21_round0')).to eq(false)
     end
 
     it 'returns true if round 0 has started' do
-      expect(qlwc.round_started?('qlwc21_round0', DATES[1])).to eq(true)
+      qlwc = Qlwc.new(DATES[1])
+      expect(qlwc.round_started?('qlwc21_round0')).to eq(true)
     end
   end
 
   describe 'round_finished?' do
     it 'returns false if round 1 has not finished' do
-      expect(qlwc.round_finished?('qlwc21_round1', DATES[5])).to eq(false)
+      qlwc = Qlwc.new(DATES[5])
+      expect(qlwc.round_finished?('qlwc21_round1')).to eq(false)
     end
 
     it 'returns true if round 1 has finished' do
-      expect(qlwc.round_finished?('qlwc21_round1', DATES[7])).to eq(true)
+      qlwc = Qlwc.new(DATES[7])
+      expect(qlwc.round_finished?('qlwc21_round1')).to eq(true)
     end
   end
 
   describe 'hidden_maps' do
     it 'returns all maps if round 0 has not finished' do
-      expect(qlwc.hidden_maps(DATES[0])).to eq(Qlwc::MAPS)
+      qlwc = Qlwc.new(DATES[0])
+      expect(qlwc.hidden_maps).to eq(Qlwc::MAPS)
     end
 
     it 'returns round1-round4 if round 1 has finished' do
       result = Qlwc::MAPS[1..]
-      expect(qlwc.hidden_maps(DATES[4])).to eq(result)
+      qlwc = Qlwc.new(DATES[4])
+      expect(qlwc.hidden_maps).to eq(result)
     end
 
     it 'returns empty array if round 4 has finished' do
-      expect(qlwc.hidden_maps(DATES[11])).to eq([])
+      qlwc = Qlwc.new(DATES[11])
+      expect(qlwc.hidden_maps).to eq([])
     end
   end
 end

--- a/spec/lib/qlwc_spec.rb
+++ b/spec/lib/qlwc_spec.rb
@@ -12,7 +12,7 @@ DATES = [Time.utc(2021, 4, 17), Time.utc(2021, 4, 17, 19),
 RSpec.describe Qlwc do
   describe 'current_map' do
     it 'returns nil if time is before qlwc21 started' do
-      qlwc = Qlwc.new(Time.utc(2021, 4, 13))
+      qlwc = described_class.new(Time.utc(2021, 4, 13))
       expect(qlwc.current_map).to be_nil
     end
 
@@ -22,7 +22,7 @@ RSpec.describe Qlwc do
                  'qlwc21_round2', 'qlwc21_round3', 'qlwc21_round4', nil]
       DATES.zip(results).each do |date, result|
         # puts "#{date} #{result}"
-        qlwc = Qlwc.new(date)
+        qlwc = described_class.new(date)
         expect(qlwc.current_map).to eq(result)
       end
     end
@@ -30,59 +30,59 @@ RSpec.describe Qlwc do
 
   describe 'round_active?' do
     it 'returns false if map is not a qlwc map' do
-      qlwc = Qlwc.new(DATES[0])
+      qlwc = described_class.new(DATES[0])
       expect(qlwc.round_active?('trinity')).to eq(false)
     end
 
     it 'returns false if round 0 has not started' do
-      qlwc = Qlwc.new(DATES[0])
+      qlwc = described_class.new(DATES[0])
       expect(qlwc.round_active?('qlwc21_round0')).to eq(false)
     end
 
     it 'returns true if round 1 is active' do
-      qlwc = Qlwc.new(DATES[5])
+      qlwc = described_class.new(DATES[5])
       expect(qlwc.round_active?('qlwc21_round1')) == true
     end
   end
 
   describe 'round_started?' do
     it 'returns false if round 0 has not started' do
-      qlwc = Qlwc.new(DATES[0])
+      qlwc = described_class.new(DATES[0])
       expect(qlwc.round_started?('qlwc21_round0')).to eq(false)
     end
 
     it 'returns true if round 0 has started' do
-      qlwc = Qlwc.new(DATES[1])
+      qlwc = described_class.new(DATES[1])
       expect(qlwc.round_started?('qlwc21_round0')).to eq(true)
     end
   end
 
   describe 'round_finished?' do
     it 'returns false if round 1 has not finished' do
-      qlwc = Qlwc.new(DATES[5])
+      qlwc = described_class.new(DATES[5])
       expect(qlwc.round_finished?('qlwc21_round1')).to eq(false)
     end
 
     it 'returns true if round 1 has finished' do
-      qlwc = Qlwc.new(DATES[7])
+      qlwc = described_class.new(DATES[7])
       expect(qlwc.round_finished?('qlwc21_round1')).to eq(true)
     end
   end
 
   describe 'hidden_maps' do
     it 'returns all maps if round 0 has not finished' do
-      qlwc = Qlwc.new(DATES[0])
+      qlwc = described_class.new(DATES[0])
       expect(qlwc.hidden_maps).to eq(Qlwc::MAPS)
     end
 
     it 'returns round1-round4 if round 1 has finished' do
       result = Qlwc::MAPS[1..]
-      qlwc = Qlwc.new(DATES[4])
+      qlwc = described_class.new(DATES[4])
       expect(qlwc.hidden_maps).to eq(result)
     end
 
     it 'returns empty array if round 4 has finished' do
-      qlwc = Qlwc.new(DATES[11])
+      qlwc = described_class.new(DATES[11])
       expect(qlwc.hidden_maps).to eq([])
     end
   end


### PR DESCRIPTION
- Hides cup times for unfinished rounds from the website and API
- Only allows times to be set while round is active